### PR TITLE
CI: remove useless lines from cxpilot-build.yml

### DIFF
--- a/.github/workflows/cxpilot-build.yml
+++ b/.github/workflows/cxpilot-build.yml
@@ -203,10 +203,8 @@ jobs:
             CFG_NAME=$(gh repo view $CFG_URL --json name -q .name)
             STATUS_JSON="$(jq -c --arg k "$CFG_NAME" --arg v "$CFG_SHA" '. + {($k):$v}' <<<"$STATUS_JSON")"
           fi
-          if [[ "STATUS_JSON" != '{}' ]]; then
-            echo "status_json=$STATUS_JSON" >> "$GITHUB_OUTPUT"
-            echo "$STATUS_JSON" > status-map.json
-          fi
+          echo "status_json=$STATUS_JSON" >> "$GITHUB_OUTPUT"
+          echo "$STATUS_JSON" > status-map.json
 
       - name: Upload status map
         if: ${{ steps.out.outputs.status_json != '{}' }}


### PR DESCRIPTION
Clearly this was meant to be "$STATUS_JSON", not "STATUS_JSON". This bug means the if-block always executes, which is actually fine, since post-status.yml already correctly handles the empty json case.

This PR is a non-functional change.
