### PR TITLE
CI: fix release build

### DIFF
--- a/.github/workflows/cxpilot-build.yml
+++ b/.github/workflows/cxpilot-build.yml
@@ -78,7 +78,6 @@ jobs:
             echo "  tag:     ${{ github.event.release.tag_name }}"
             FEATURE_REF=""
             BASE_REF="${{ github.event.release.tag_name }}"
-            S3_ROOT="${{ vars.S3_RELEASE_ROOT }}"
           else
             echo "ERROR: Unsupported event ${{ github.event_name }}" >&2
             exit 1
@@ -92,11 +91,11 @@ jobs:
           resolve_ref() {
             local url="$1" ref="$2" fb="$3"
             local sha found_ref
-            sha="$(git ls-remote --heads "$url" "refs/heads/$ref" | awk '{print $1}')"
+            sha="$(git ls-remote "$url" "refs/heads/$ref" "refs/tags/$ref" | awk '{print $1}')"
             if [[ -n "$sha" ]]; then
               found_ref="$ref"
             else
-              sha="$(git ls-remote --heads "$url" "refs/heads/$fb" | awk '{print $1}')"
+              sha="$(git ls-remote "$url" "refs/heads/$fb" "refs/tags/$fb" | awk '{print $1}')"
               if [[ -n "$sha" ]]; then
                 found_ref="$fb"
               else
@@ -156,7 +155,7 @@ jobs:
           COMMIT_ID="${INTEG_SHA:0:4}_${CORE_SHA:0:4}_${CFG_SHA:0:4}"
           if [[ ${{ github.event_name }} == 'release' ]]; then
             S3_ROOT="${{ vars.S3_RELEASE_ROOT }}"
-            FOLDER_NAME="${DATE_HR}_${FIRMWARE_VERSION}_${#INTEG_SHA:0:8}"
+            FOLDER_NAME="${DATE_HR}_${FIRMWARE_VERSION}_${INTEG_SHA:0:8}"
           elif [[ -n "$FEATURE_REF" ]]; then
             S3_ROOT="${{ vars.S3_DEV_ROOT }}/Feature/${BASE_REF//\//-}"
             # For feature builds, use the JIRA ID instead of the firmware version

--- a/.github/workflows/cxpilot-build.yml
+++ b/.github/workflows/cxpilot-build.yml
@@ -18,11 +18,6 @@ on:
         description: 'Feature branch (optional)'
         required: false
         default: ''
-      skip_s3_upload:
-        description: 'Skip upload to S3 (for testing)'
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: read
@@ -269,7 +264,6 @@ jobs:
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           python tools/build/build_aircraft.py  --clean --require-clean-git --config "${{ matrix.config }}"
       - name: Upload to S3
-        if: ${{ inputs.skip_s3_upload != 'false' }}
         uses: ./.github/actions/s3-upload
         with:
           s3_path: ${{ needs.set-up-variables.outputs.s3_path }}
@@ -339,7 +333,6 @@ jobs:
           set -e
           python tools/build/build_cpns.py --generate
       - name: Upload to S3
-        if: ${{ inputs.skip_s3_upload != 'false' }}
         uses: ./.github/actions/s3-upload
         with:
           s3_path: ${{ needs.set-up-variables.outputs.s3_path }}
@@ -525,7 +518,6 @@ jobs:
       folder_name: ${{ needs.set-up-variables.outputs.folder_name }}
     steps:
       - uses: actions/checkout@v5
-        if: ${{ inputs.skip_s3_upload != 'false' }}
         with:
           ref: ${{ needs.set-up-variables.outputs.integration_sha }}
           submodules: false
@@ -543,7 +535,6 @@ jobs:
           path: output/sitl
       # Easier to upload the sitl folder at this stage than inside the windows container
       - name: Upload SITL to S3
-        if: ${{ inputs.skip_s3_upload != 'false' }}
         uses: ./.github/actions/s3-upload
         with:
           s3_path: ${{ needs.set-up-variables.outputs.s3_path }}/sitl
@@ -566,7 +557,6 @@ jobs:
           path: ${{ env.folder_name }}.7z
           retention-days: 15
       - name: Upload to S3
-        if: ${{ inputs.skip_s3_upload != 'false' }}
         uses: ./.github/actions/s3-upload
 
         with:

--- a/.github/workflows/cxpilot-build.yml
+++ b/.github/workflows/cxpilot-build.yml
@@ -501,7 +501,7 @@ jobs:
       - name: Check Vehicle Parameters
         run: python cxpilot-config/tools/param_check.py --vehicle=Plane cxpilot-config/aircraft_params/**/*.par*m
       - name: Lua Checks
-        run:
+        run: |
           set -e
           sudo apt-get update
           sudo apt-get -y install lua-check


### PR DESCRIPTION
The build CI couldn't actually build by tag, which was a mistake that's gone unnoticed since we usually build by branch.

Several other drive-bys in this PR too.