### PR TITLE
.vscode: fix submodule nuke

### DIFF
--- a/.vscode/example.tasks.json
+++ b/.vscode/example.tasks.json
@@ -118,7 +118,10 @@
         {
             "label": "core submodule nuke",
             "type": "shell",
-            "command": "rm -r ${workspaceFolder}/cxpilot-core/modules; ${workspaceFolder}/cxpilot-core/Tools/gittools/submodule-sync.sh",
+            "command": "rm -r modules && Tools/gittools/submodule-sync.sh",
+            "options": {
+                "cwd": "${workspaceFolder}/cxpilot-core",
+            },
             "group": {
                 "kind": "build",
                 "isDefault": true,


### PR DESCRIPTION
This was running the script one directory too high, causing core/config checkout to the submodule pinned hashes. We only want to update core's submodules, not the top-level ones.