### PR TITLE
gitmodules: ignore submodule status during dev

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "cxpilot-core"]
 	path = cxpilot-core
 	url = https://github.com/CarbonixUAV/cxpilot-core
+	ignore = all
 [submodule "cxpilot-config"]
 	path = cxpilot-config
 	url = https://github.com/CarbonixUAV/cxpilot-config
+	ignore = all

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -26,3 +26,9 @@ to publish the release artifacts to the release folder in S3.
 This procedure is not enforced in CI on the release PR (though it should some
 day). The Build CI does enforce the tag/submodule SHA match when building
 though.
+
+The submodules are configured with `ignore = all` in `.gitmodules`. This
+prevents git from showing them as modified during development (when they're
+intentionally ahead of the parent repo's pointers). When preparing the release
+PR, you must explicitly stage the submodule updates with `git add cxpilot-core
+cxpilot-config` after checking out the tagged commits.


### PR DESCRIPTION
This reduces friction. This stops our two submodules from constantly showing up as uncommitted changes.

This does not interfere with your ability to `git add` them to update (as part of our release process), and `git submodule update --recursive` still works if you want to do that on a tagged release or something.

This interferes with the dirty markers in the config tooling slightly, so there is a companion PR to fix this in `cxpilot-config`: https://github.com/CarbonixUAV/cxpilot-config/pull/15