### PR TITLE
CxPilot-8.0.2 Release

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,3 +1,12 @@
+Release 8.0.2 20th April 2026
+------------------------------------------------------------------
+
+Minor parameter patch to allow Cube NET direct link through LTE1/2 for Ottano
+
+### Ottano Changes
+
+- Ottano: NET direct link through LTE1/2
+
 Release 8.0.1 8th April 2026
 ------------------------------------------------------------------
 

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-CxPilot-8.0.2
+CxPilot-8.1.0-dev

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-CxPilot-8.1.0-dev
+CxPilot-8.0.2


### PR DESCRIPTION
Release 8.0.2 20th April 2026
------------------------------------------------------------------

Minor parameter patch to allow Cube NET direct link through LTE1/2 for Ottano

### Ottano Changes

- Ottano: NET direct link through LTE1/2