### PR TITLE
build(deps): bump the github-actions group with 6 updates

### DIFF
--- a/.github/actions/s3-upload/action.yml
+++ b/.github/actions/s3-upload/action.yml
@@ -24,7 +24,7 @@ runs:
   using: "composite"
   steps:
     - name: Install AWS CLI
-      if: ${{ inputs.install_aws_cli == 'true' }}
+      if: ${{ inputs.install_aws_cli == 'true' && github.actor != 'dependabot[bot]' }}
       shell: bash
       run: |
         set -e
@@ -34,7 +34,10 @@ runs:
         unzip -q awscliv2.zip
         ./aws/install --update
 
+    # Dependabot runs can't access secrets (AWS creds resolve empty), so skip
+    # the upload entirely — the build still compiles and verifies.
     - name: Configure AWS credentials
+      if: ${{ github.actor != 'dependabot[bot]' }}
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.aws_key_id }}
@@ -42,6 +45,7 @@ runs:
         aws-region: ${{ inputs.aws_region }}
 
     - name: Upload to S3
+      if: ${{ github.actor != 'dependabot[bot]' }}
       shell: bash
       run: |
         set -e

--- a/.github/workflows/cxpilot-build.yml
+++ b/.github/workflows/cxpilot-build.yml
@@ -42,7 +42,7 @@ jobs:
       bases:            ${{ steps.out.outputs.bases }}
       status_json:      ${{ steps.out.outputs.status_json }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: false
       - id: out
@@ -204,13 +204,13 @@ jobs:
 
       - name: Upload status map
         if: ${{ steps.out.outputs.status_json != '{}' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: status-map
           path: status-map.json
       - name: Generate token to post statuses
         if: ${{ steps.out.outputs.status_json != '{}' }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app
         with:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
@@ -219,7 +219,7 @@ jobs:
           repositories: cxpilot, cxpilot-core, cxpilot-config
       - name: Post pending statuses
         if: ${{ steps.out.outputs.status_json != '{}' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           STATUS_JSON: ${{ steps.out.outputs.status_json }}
         with:
@@ -249,7 +249,7 @@ jobs:
       matrix:
         config: ${{ fromJson(needs.set-up-variables.outputs.configs) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-up-variables.outputs.integration_sha }}
           submodules: false
@@ -272,7 +272,7 @@ jobs:
           aws_secret: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: ${{ vars.AWS_S3_REGION }}
           install_aws_cli: true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: output-fc-${{ matrix.config }}
           path: output
@@ -288,7 +288,7 @@ jobs:
       matrix:
         base: ${{ fromJson(needs.set-up-variables.outputs.bases) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-up-variables.outputs.integration_sha }}
           submodules: false
@@ -301,7 +301,7 @@ jobs:
           set -e
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           python tools/build/build_cpns.py --clean --require-clean-git --build-base "${{ matrix.base }}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: base-${{ matrix.base }}
           path: build/base_builds
@@ -312,7 +312,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [set-up-variables, build-periph-bases]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-up-variables.outputs.integration_sha }}
           submodules: false
@@ -322,7 +322,7 @@ jobs:
           core_ref:        ${{ needs.set-up-variables.outputs.core_sha }}
           core_tools_only: true # Only need core for apj_tool
       - name: Fetch base artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: build/base_builds
           pattern: base-*
@@ -340,7 +340,7 @@ jobs:
           aws_key_id: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
           aws_secret: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
           aws_region: ${{ vars.AWS_S3_REGION }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: output-cpns
           path: output
@@ -353,7 +353,7 @@ jobs:
     steps:
       # We can't use checkout-triple here because it's tricky with Cygwin,
       # so we manually checkout the right SHAs later
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-up-variables.outputs.integration_sha }}
           submodules: 'recursive'
@@ -405,14 +405,14 @@ jobs:
           echo "CCACHE_DIR=$(cygpath -w ${CCACHE_DIR})" >> $GITHUB_OUTPUT
           echo "BASEDIR=$(cygpath -w ${CCACHE_BASEDIR})" >> $GITHUB_OUTPUT
       - name: ccache cache files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.setup_ccache.outputs.CCACHE_DIR }}
           key: ${{ steps.ccache_cache_timestamp.outputs.cache-key }}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
           restore-keys: ${{ steps.ccache_cache_timestamp.outputs.cache-key }}-ccache-  # restore ccache from either previous build on this branch or on base branch
       - name: cache executable
         id: sitl_exe_cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.setup_ccache.outputs.BASEDIR }}/cxpilot-core/build/sitl/bin
           # We name/cache the SITL based on the core SHA, since all the config stuff is baked into the companion files,
@@ -475,7 +475,7 @@ jobs:
           done
       
       - name: Upload SITL artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sitl
           path: sitl
@@ -486,7 +486,7 @@ jobs:
     needs: set-up-variables
     container: ardupilot/ardupilot-dev-base:v0.1.3
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-up-variables.outputs.integration_sha }}
           submodules: false
@@ -521,19 +521,19 @@ jobs:
     env:
       folder_name: ${{ needs.set-up-variables.outputs.folder_name }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-up-variables.outputs.integration_sha }}
           submodules: false
           sparse-checkout: .github/actions/s3-upload
       - name: Download artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: output-*
           path: output
           merge-multiple: true
       - name: Download sitl
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: sitl
           path: output/sitl
@@ -555,7 +555,7 @@ jobs:
           cd ..
           ls -lR .
       - name: Upload 7z folder to artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.folder_name }}
           path: ${{ env.folder_name }}.7z

--- a/.github/workflows/cxpilot-build.yml
+++ b/.github/workflows/cxpilot-build.yml
@@ -213,7 +213,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app
         with:
-          app-id: ${{ secrets.CI_BOT_APP_ID }}
+          client-id: ${{ secrets.CI_BOT_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: cxpilot, cxpilot-core, cxpilot-config

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for changes since last successful nightly and trigger build
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/post-status.yml
+++ b/.github/workflows/post-status.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app
         with:
-          app-id: ${{ secrets.CI_BOT_APP_ID }}
+          client-id: ${{ secrets.CI_BOT_CLIENT_ID }}
           private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: cxpilot, cxpilot-core, cxpilot-config

--- a/.github/workflows/post-status.yml
+++ b/.github/workflows/post-status.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Check for status-map artifact
         id: probe
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -24,7 +24,7 @@ jobs:
 
       - if: ${{ steps.probe.outputs.found == 'true' }}
         name: Download status-map
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
           path: .
 
       - if: ${{ steps.probe.outputs.found == 'true' }}
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         id: app
         with:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
@@ -42,7 +42,7 @@ jobs:
 
       - if: ${{ steps.probe.outputs.found == 'true' }}
         name: Post final status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app.outputs.token }} # or create-github-app-token first
           script: |


### PR DESCRIPTION
This PR does three things:

- Clones dependabot's PR: https://github.com/CarbonixUAV/cxpilot/pull/22
- Updates from deprecated app-id to client-id for the ci bot
- Skips CI steps for future dependabot PRs that require secrets

For good security reasons, dependabot PR runs aren't allowed access to secrets. If you want to test CI for a dependabot PR before merging, simply clone the PR and open it yourself. I think most really simple bumps in the future are fine to yolo merge without CI. Can always test with a manual dispatch too.