### PR TITLE
ci: dependabot scans composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Dependabot wasn't scanning my subdirectories. `.github/actions/s3-upload/action.yml` has some pins that need a bump. I'll bump them later. Checking to see that it picks these up on Monday